### PR TITLE
readme: fix json errors in .hyper.js example

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,6 @@ Finally, edit `~/.hyper.js` and add the package to the `localPlugins` array:
 
     ...
     localPlugins: [
-      'themer-hyper-dark`,
+      'themer-hyper-dark'
     ],
     ...


### PR DESCRIPTION
with #1 fixed, I proceeded to follow the readme instructions to get the generated code into my hyperterm. encountered two copy/paste errors along the way